### PR TITLE
fix(editor): update editor language on text paste

### DIFF
--- a/src/components/SpecEditor.vue
+++ b/src/components/SpecEditor.vue
@@ -34,6 +34,7 @@ import { ref, computed, useTemplateRef, watch } from 'vue'
 import { KEmptyState } from '@kong/kongponents'
 import { CodeblockIcon, ProgressIcon } from '@kong/icons'
 import useMonacoEditor from '@/composables/useMonacoEditor'
+import { isJsonOrYaml } from '@/utils/oas'
 
 // Props
 const content = defineModel<string>({
@@ -47,11 +48,7 @@ const lang = ref<'json' | 'yaml'>('json')
 const isLoading = computed(() => false)
 
 watch(content, (newContent) => {
-  if (newContent.startsWith('{') || newContent.startsWith('[')) {
-    lang.value = 'json'
-  } else {
-    lang.value = 'yaml'
-  }
+  lang.value = isJsonOrYaml(newContent)
 }, { immediate: true })
 
 const { formatDocument } = useMonacoEditor(containerRef, {

--- a/src/composables/useMonacoEditor.ts
+++ b/src/composables/useMonacoEditor.ts
@@ -14,6 +14,7 @@ import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker
 import { shikiToMonaco } from '@shikijs/monaco'
 import { createHighlighter } from 'shiki'
 import type { HighlighterGeneric, BundledLanguage, BundledTheme } from 'shiki'
+import { isJsonOrYaml } from '@/utils/oas'
 
 interface UseMonacoEditorOptions {
   /** Is the Editor readonly. */
@@ -322,6 +323,11 @@ export default function useMonacoEditor(target: Ref, options: UseMonacoEditorOpt
       })
 
       editor?.onDidPaste((): void => {
+        const content = editor?.getValue() || ''
+
+        lang = isJsonOrYaml(content)
+
+        monacoInstance.editor.setModelLanguage(model, lang)
         formatDocument()
       })
     },

--- a/src/utils/oas.ts
+++ b/src/utils/oas.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks if the provided content is in JSON or YAML format.
+ *
+ * @param content The content to check if it is JSON or YAML
+ * @returns 'json' if the content is JSON, 'yaml' if it is YAML
+ */
+export const isJsonOrYaml = (content: string): 'json' | 'yaml' => {
+  if (content.startsWith('{') || content.startsWith('[')) {
+    return 'json'
+  } else {
+    return 'yaml'
+  }
+}


### PR DESCRIPTION
# Description

The editor language needs to be updated when user pastes text in the editor.

## Changes

- add `jsonOrYaml` util method to find out content type
- update editor language whenever text is pasted into the editor

Forked out from @arashsheyda's fix in https://github.com/Kong/spec-editor/pull/91