### PR TITLE
refactor(editor): remove unnecessary fileKey and simplify language handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -111,7 +111,6 @@
           </template>
         </SpecToolbar>
         <SpecEditor
-          :key="fileKey"
           ref="editor"
           v-model="code"
         />
@@ -254,8 +253,6 @@ const isMobile = computed(() => width.value <= 768)
 const code = ref(JSON.stringify(files[0][1].file, null, 2))
 const specText = refDebounced(code, 700)
 
-// to force re-render of the editor when the spec changes
-const fileKey = ref<number>(0)
 // to track if the spec has been cleared
 const isCleared = ref(false)
 
@@ -298,14 +295,11 @@ const clearSpec = () => {
 
   isCleared.value = true
   code.value = ''
-  fileKey.value++
 }
 
 const resetEditor = () => {
   isCleared.value = false
-  fileKey.value++
 }
-
 
 const dropzoneClick = () => {
   fileInputRef.value?.click()

--- a/src/components/SpecEditor.vue
+++ b/src/components/SpecEditor.vue
@@ -30,11 +30,10 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, useTemplateRef, watch } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { KEmptyState } from '@kong/kongponents'
 import { CodeblockIcon, ProgressIcon } from '@kong/icons'
 import useMonacoEditor from '@/composables/useMonacoEditor'
-import { isJsonOrYaml } from '@/utils/oas'
 
 // Props
 const content = defineModel<string>({
@@ -42,20 +41,10 @@ const content = defineModel<string>({
 })
 
 const containerRef = useTemplateRef('containerRef')
-
-const lang = ref<'json' | 'yaml'>('json')
-
 const isLoading = computed(() => false)
 
-watch(content, (newContent) => {
-  lang.value = isJsonOrYaml(newContent)
-}, { immediate: true })
-
 const { formatDocument } = useMonacoEditor(containerRef, {
-  language: lang.value,
   code: content,
-  forceTheme: 'light',
-  readOnly: false,
   onChanged: (newContent) => {
     content.value = newContent
   },


### PR DESCRIPTION
# Description

this PR simplifies the editor
- by adding default values to some options
- updating the content and languages in the composables (and removing the editor re-rendering manually)
- some performance improvements like lazy load monaco editor and spectral (this was initially done to work with Nuxt)


to test:
- load an api: from samples or upload
- play with the editor