### PR TITLE
chore(editor): increase timeout for Shiki to Monaco highlighter setup

### DIFF
--- a/src/composables/useMonacoEditor.ts
+++ b/src/composables/useMonacoEditor.ts
@@ -96,7 +96,7 @@ const setupMonaco = async (): Promise<{ monacoInstance: IMonacoEditor }> => {
 
   setTimeout(() => {
     shikiToMonaco(shikiHighlighter, monacoInstance)
-  }, 100)
+  }, 200)
 
   return { monacoInstance }
 }


### PR DESCRIPTION
increasing the timeout to see the code highlighting would load on first page load