### PR TITLE
ci: renovate bot name change [TDX-6743]

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   renovate-autoapprove:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'renovate[bot]' }}
+    if: ${{ github.actor == 'renovate[bot]' || github.actor == 'mend[bot]' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1


### PR DESCRIPTION
# Description

Renovate is changing their github app name https://github.com/renovatebot/renovate/discussions/37842

ticket: https://konghq.atlassian.net/browse/TDX-6743