### PR TITLE
fix: update scrolling container for spec-renderer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -151,7 +151,7 @@
           v-show="!isCleared && !isLoading"
           class="spec-renderer"
           :control-address-bar="true"
-          document-scrolling-container=".spec-renderer-pane"
+          document-scrolling-container=".split-pane-right"
           :spec="specText"
           v-bind="options"
         />


### PR DESCRIPTION
# Description

Update the class spec-renderer was using to hook onto for scroll events. This broke because we moved away from split-panes to our own splitpane library