### PR TITLE
chore(ci): bumping pr-audit action [KHCP-21463]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+# Description
+
+<!--
+Add Jira ticket number to the title of the PR.
+
+- Mention what issue or requirement does this PR address.
+- How was this issue solved or the feature implemented?
+- What areas of the system will this PR affect?
+-->
+
+<!-- Uncomment any applicable sections from below and answer as needed. -->
+
+<!--
+## Screenshots (Optional)
+Add any screenshots (if applicable) to provide visual context.
+-->
+
+<!--
+## Post-merge tasks (Optional)
+Any tasks that needs to be completed post-merge.
+-->
+
+<!--
+## Additional comments (Optional)
+The following points are provided as a guide to help ensure your PR is thorough and well-prepared. Consider these questions as you review your changes:
+
+- Does the code meet the requirements in the Jira ticket?
+- Are all acceptance criteria satisfied?
+- Are edge cases handled appropriately?
+- Is the code readable and maintainable?
+- Are there clear comments for complex logic?
+- Does the code follow project standards and linting guidelines?
+- Are there sufficient unit/component/e2e tests with meaningful coverage?
+- Are there tests for new/updated functionality?
+- Are all tests passing locally?
+- Are potential risks or breaking changes identified?
+- Does the change impact other areas of the system? If yes, are they addressed?
+-->
+
+<!--
+## Test Coverage Exemption (Optional)
+If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.
+
+[TEST_COVERAGE_EXEMPT_REASON] give it a reason
+-->

--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -9,15 +9,10 @@ on:
       - reopened
       - labeled
       - unlabeled
-
-  pull_request_review:
-    types:
-      - submitted
       - edited
-      - dismissed
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -41,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-with-dependencies/
 
       - name: PR Audit
-        uses: Kong/public-shared-actions/pr-previews/audit@main
+        uses: Kong/public-shared-actions/pr-previews/audit@cbbbf31a69c4f38d1803ededb69acb2a86836f85
         if: github.actor != 'renovate[bot]'
         with:
           renovate-pr-author: renovate[bot]


### PR DESCRIPTION
# Description

as per manager complains: "but every time I approve one of these I feel like I’m rubber stamping to get past a gate."

So: no longer PR without test coverage requires manager's approval. Instead it requires PR author to put test-exempt-reason into PR description:

<img width="936" height="432" alt="image" src="https://github.com/user-attachments/assets/42e624a9-693f-4db0-97c7-fa7e69cc7def" />